### PR TITLE
added limit option in order to prevent downloading tons of data

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ var MetaInspector = function(url, options){
 	this.scheme = this.parsedUrl.scheme;
 	this.host = this.parsedUrl.host;
 	this.rootUrl = this.scheme + "://" + this.host;
+    this.removeAllListeners();
 };
 
 MetaInspector.prototype = new events.EventEmitter();


### PR DESCRIPTION
node-metainspector  can explode if is provided an url that links to big file such an ISO file.
to avoid this problem i have added an option parameter that limits the downloaded data made from the request object.
with my change, the following code:

```
var MetaInspector  = require('node-metainspector');

var client = new MetaInspector("http://cdimage.debian.org/debian-cd/7.5.0/amd64/iso-cd/debian-7.5.0-amd64-CD-1.iso", { limit: 1024});

client.on("fetch", function(){
    console.log("Description: " + client.description());

    console.log("Links: " + client.links().join(","));
});

client.on("error", function(err){
    console.log(error);
});

client.on("limit", function(){
    console.log("limit reached!");
});

client.fetch();
```

avoids that the iso is fully downloaded, as the request is aborted after the first 1024 bytes and event  "limit" is emmitted.

Let me know what do you think of this and i can write you also the tests.
thank you,
Miro
