### PR TITLE
Return data for `fetch` event

### DIFF
--- a/index.js
+++ b/index.js
@@ -309,7 +309,7 @@ MetaInspector.prototype.fetch = function(){
 
 			_this.initAllProperties();
 
-			_this.emit("fetch");
+			_this.emit("fetch", _this);
 		}
 		else{
 			_this.emit("error", error);


### PR DESCRIPTION
Can not pass result async when using koa. [co-event](https://github.com/segmentio/co-event) can capture the event value via emit as sync.

Returns events in sequence, with the `.type` and `.args` keys. 

``` js
var event = require('co-event');
var MetaInspector = require('node-metainspector');

var client = new MetaInspector('http://google.com', { timeout: 5000 });
client.fetch();

// Because this.body in koa server can not wait MetaInspector fetch done. 
// I using co-event to yield an event

var e;
while (e = yield event(client)) {
    console.log(e)
    switch (e.type) {
        case 'fetch':
            return this.body = e.args[0]; // need emit value here
            break;

        case 'error':
        default:
            return this.body = {};
            break;
    }
}
```

So, I want add return for emit `fetch` event. 
