### PR TITLE
Fixes a typo in the provided example code: s/error/err

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ client.on("fetch", function(){
 });
 
 client.on("error", function(err){
-	console.log(error);
+	console.log(err);
 });
 
 client.fetch();


### PR DESCRIPTION
Hi gabceb,

Nothing special, just fixes a "typo". When pasting that code in & testing out your library, if you change the url to something that would cause an error, it breaks.

Also, your library is working great!

Thanks!