### PR TITLE
passing all options to the request call, not just the chosen few

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,22 +20,22 @@ function withDefaultScheme(url){
 
 var MetaInspector = function(url, options){
 	this.url = URI.normalize(withDefaultScheme(url));
-	this.options = options || {};
 
 	this.parsedUrl = URI.parse(this.url);
 	this.scheme = this.parsedUrl.scheme;
 	this.host = this.parsedUrl.host;
 	this.rootUrl = this.scheme + "://" + this.host;
 
+	this.options = options || {};
 	//default to a sane limit, since for meta-inspector usually 5 redirects should do a job
 	//more over beyond this there could be an issue with event emitter loop detection with new nodejs version
 	//which prevents error event from getting fired
-	this.maxRedirects = this.options.maxRedirects || 5;
+	this.options.maxRedirects = this.options.maxRedirects || 5;
 
-	//some urls are timing out after one minute, hence need to specify a reasoable default timeout
-	this.timeout = this.options.timeout || 20000; //Timeout in ms
+	//some urls are timing out after one minute, hence need to specify a reasonable default timeout
+	this.options.timeout = this.options.timeout || 20000; //Timeout in ms
 
-	this.strictSSL = !!this.options.strictSSL;
+	this.options.strictSSL = !!this.options.strictSSL;
 };
 
 //MetaInspector.prototype = new events.EventEmitter();
@@ -300,8 +300,7 @@ MetaInspector.prototype.getAbsolutePath = function(href){
 MetaInspector.prototype.fetch = function(){
 	var _this = this;
 	var totalChunks = 0;
-
-	var r = request({uri : this.url, gzip: true, maxRedirects: this.maxRedirects, timeout: this.timeout, strictSSL: this.strictSSL}, function(error, response, body){
+	var r = request(Object.assign({uri : this.url, gzip: true}, this.options), function(error, response, body){
 		if(!error && response.statusCode === 200){
 			_this.document = body;
 			_this.parsedDocument = cheerio.load(body);


### PR DESCRIPTION
Rather than just seeing to the few options explicitly, this allows all options to be passed through to the request call.

I've added this, as I need to pass header values to the request.

The only value not used in the request is options.limit, and I don't see any harm in allowing that to be passed to the request.