### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "cheerio": "~0.19.0",
     "lodash": "^4.12.0",
-    "request": "~2.58.0",
+    "request": "~2.74.0",
     "uri-js": "~2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
node-metainspector currently has a 2 vulnerable dependency paths, introducing 2 different types of known vulnerabilities.

This PR fixes vulnerable dependencies, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.

You can see [Snyk test report](https://snyk.io/test/github/gabceb/node-metainspector) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerabilities.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Team