### PR TITLE
Change cheerio version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Gabriel Cebrian <gabceb@gmail.com> (http://about.me/gabceb)",
   "main": "./index.js",
   "dependencies": {
-    "cheerio": "~0.19.0",
+    "cheerio": "~0.22.0",
     "lodash": "^4.12.0",
     "request": "~2.74.0",
     "uri-js": "~2.1.0"


### PR DESCRIPTION
(cheerio/index.js)'exports.version = require('./package');' <-- 0.19.0
This sentence generates errors.

"Cannot find module './package'" 

and This sentence should be change to 'exports.version =
require('./package,json').version;' < -- 0.22.0