### PR TITLE
Include port number in client.rootUrl if specified in original url

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Metainspector is inspired by the Metainspector gem by [jaimeiniesta](https://git
 client.url                  # URL of the page
 client.scheme               # Scheme of the page (http, https)
 client.host                 # Hostname of the page (like, markupvalidator.com, without the scheme)
-client.rootUrl              # Root url (scheme + host, i.e http://simple.com/)
+client.port                 # Port number of the page, as number (undefined if url doesn't specify port)
+client.rootUrl              # Root url (scheme + host + port, i.e http://simple.com:8000/ or http://simple.com/ if no port specified)
 client.title                # title of the page, as string
 client.links                # array of strings, with every link found on the page as an absolute URL
 client.author               # page author, as string

--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ var MetaInspector = function(url, options){
 	this.parsedUrl = URI.parse(this.url);
 	this.scheme = this.parsedUrl.scheme;
 	this.host = this.parsedUrl.host;
+	this.port = this.parsedUrl.port;
 	this.rootUrl = this.scheme + "://" + this.host;
+	this.rootUrl = this.scheme + "://" + this.host;
+	if (!_.isNil(this.port)) {
+		this.rootUrl += ":" + this.port;
+	}
 
 	this.options = options || {};
 	//default to a sane limit, since for meta-inspector usually 5 redirects should do a job

--- a/test/test.js
+++ b/test/test.js
@@ -64,10 +64,38 @@ describe('metainspector', function(){
 			done();
 		});
 
+		it('should not include port number in host', function(done){
+			client = new MetaInspector("http://www.google.com:8000");
+
+			client.host.should.equal("www.google.com");
+			done();
+		});
+
+		it('should have a port property', function(done){
+			client = new MetaInspector("http://www.google.com:8000");
+
+			client.port.should.equal(8000);
+			done();
+		});
+
+		it('port should be undefined if not specified in original url', function(done){
+			client = new MetaInspector("http://www.google.com");
+
+			should.equal(client.port, undefined);
+			done();
+		});
+
 		it('should have a rootUrl property', function(done){
 			client = new MetaInspector("http://www.google.com");
 
 			client.rootUrl.should.equal("http://www.google.com");
+			done();
+		});
+
+		it('should include port number in rootUrl if specified in original url', function(done){
+			client = new MetaInspector("http://www.google.com:8000");
+
+			client.rootUrl.should.equal("http://www.google.com:8000");
 			done();
 		});
 


### PR DESCRIPTION
Without this change, metadata that contains URLs pointing to resources on the scraped page's server will be invalid if that server is running on a non-default port (e.g. when running locally during development).