### PR TITLE
ignore script tag(s) when generating secondary description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 build
 *.node
 components
+.vscode

--- a/index.js
+++ b/index.js
@@ -146,6 +146,19 @@ MetaInspector.prototype.getMetaDescription = function()
 	return this;
 }
 
+MetaInspector.prototype.elemContainsTag = function(elem,tagName) {
+	if (elem.tagName && elem.tagName === tagName ) {
+		return true;
+	} else if ( elem.children != undefined ) {
+		for ( var i = 0; i < elem.children.length; i++) {
+			if ( this.elemContainsTag(elem.children[i], tagName) ) {
+				return true;
+			}
+		}
+	}
+	return false
+}
+
 MetaInspector.prototype.getSecondaryDescription = function()
 {
 	debug("Parsing page secondary description");
@@ -159,12 +172,12 @@ MetaInspector.prototype.getSecondaryDescription = function()
 			if(_this.description){
 				return;
 			}
-
-			var text = _this.parsedDocument(this).text();
-
-			// If we found a paragraph with more than
-			if(text.length >= minimumPLength) {
-				_this.description = text;
+			if ( ! _this.elemContainsTag(elem,"script")) {
+				var text = _this.parsedDocument(this).text();
+				// If we found a paragraph with more than
+				if(text.length >= minimumPLength) {
+					_this.description = text;
+				}
 			}
 		});
 	}

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -6,5 +6,6 @@ fakeweb.registerUri({uri: 'http://www.google.com:80/', file: path.join(__dirname
 fakeweb.registerUri({uri: 'http://www.simple.com:80/', file: path.join(__dirname, 'simple.com.html')});
 fakeweb.registerUri({uri: 'http://www.fastandfurious7-film.com:80/', file: path.join(__dirname, 'fastandfurious7-film.com.html')});
 fakeweb.registerUri({uri: 'http://www.techsuplex.com:80/', file: path.join(__dirname, 'techsuplex.com.html')});
+fakeweb.registerUri({uri: 'http://scriptinptag.html:80/', file: path.join(__dirname, 'scriptinptag.html')});
 
-fakeweb.ignoreUri({uri: 'http://www.google-404.com:80/'});
+fakeweb.registerUri({uri: 'http://www.404-response.com:80/', statusCode: 404});

--- a/test/fixtures/scriptinptag.html
+++ b/test/fixtures/scriptinptag.html
@@ -1,0 +1,39 @@
+<HTML>
+<head>
+<title>This is my title!</title>
+</head>
+<body BGCOLOR="FFFFFF">
+<center><img src="clouds.jpg" ALIGN="BOTTOM"> </center>
+<a href="http://somegreatsite.com">Link Name</a>
+is a link to another nifty site
+<h1>This is a Header</h1>
+<h2>This is a Medium Header</h2>
+Send me mail at <a href="mailto:support@yourcompany.com">
+support@yourcompany.com</a>.
+<p class="break" style="position:absolute;margin-top:-10px;margin-right:5px;">
+<!-- CONDITIONAL LOG-IN STATEMENT  /WELCOME STATEMENT -->
+<div id="convio-content-424030479" style="display: inline;">
+<!-- Standard dependencies for embedded COM content -->
+<script type="text/javascript">
+var Y;
+if (!Y) {
+  Y = YUI({
+    base: 'http://support.nationalww2museum.org/yui3/',
+    debug: false,
+    modules: getModules('http://support.nationalww2museum.org/','convio',false)
+  });
+}
+</script>
+
+<p style="float:right;font-size:12px; font-family:arial,helvetica,sans-serif;color:#1d1d1d;">
+    <a href="http://support.nationalww2museum.org/site/UserLogin">
+        <span><strong>Log In</strong></span></a> |
+    <a href="http://support.nationalww2museum.org/site/ConsProfileUser">Register</a>
+</p>
+<br style="clear:both;">
+</div>
+<!-- END -->
+</p>
+<p>World War II, which began in 1939 and ended in 1945, was the deadliest and most destructive war in history. Before the war, Germany, America, and the rest of the world were going through the Great Depression. The economy was very bad, unemployment was at an all-time high, and massive inflation caused money to lose its value. More than fifty nations in the world were fighting, with more than 100 million soldiers deployed. Countries like America and Britain were part of the Allied powers. Japan and Germany were part of the Axis powers.</p>
+</body>
+</HTML>

--- a/test/test.js
+++ b/test/test.js
@@ -225,6 +225,15 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
+		it("should ignore any p tag with embedded script tag(s) when searching for secondary description", function (done) {
+			client = new MetaInspector("http://scriptinptag.html", {});
+			client.once("fetch", function(){
+				client.description.should.equal("World War II, which began in 1939 and ended in 1945, was the deadliest and most destructive war in history. Before the war, Germany, America, and the rest of the world were going through the Great Depression. The economy was very bad, unemployment was at an all-time high, and massive inflation caused money to lose its value. More than fifty nations in the world were fighting, with more than 100 million soldiers deployed. Countries like America and Britain were part of the Allied powers. Japan and Germany were part of the Axis powers.");
+				done();
+			});
+			client.fetch();
+		});
+
 		it('should find a the image based on the og:image tag if defined', function(done){
 			client = new MetaInspector("http://www.simple.com", {});
 
@@ -275,11 +284,10 @@ describe('metainspector', function(){
 			client.fetch();
 		});
 
-		it('should emit errors', function(done){
-			client = new MetaInspector("http://www.google-404.com/", {});
+		it('should emit errors on http error response', function(done){
+			client = new MetaInspector("http://www.404-response.com", {});
 
 			client.once("error", function(error){
-				should.exists(error);
 				done();
 			});
 


### PR DESCRIPTION
`p` tags are used to generate the description when other methods fail. However, there are cases where the `p` tag may have internal script tags which do not make sense as part of a website description. This fix ignores any `p` tag with internal script tags when generating a secondary description.

In addition this PR includes a fix for the "client should emit errors" test which was previously failing on a async test timeout error.